### PR TITLE
fix High DPI (HiDPI) scaling issues in TkinterDnD2

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,14 @@ import re
 import sys
 import tempfile
 
+if os.name == "nt":
+    import ctypes
+    try:
+        # fix High DPI (HiDPI) scaling issues in TkinterDnD2
+        ctypes.windll.shcore.SetProcessDpiAwareness(1)  # 1 = System Aware
+    except Exception:
+        ctypes.windll.user32.SetProcessDPIAware()  # Fallback for older Windows
+
 if sys.platform != 'darwin':
     import notifypy
     # fix: UnsupportedPlatform exception on Windows 11 and Python 3.12 by TransparentLC · Pull Request #55 · ms7m/notify-py


### PR DESCRIPTION
fix High DPI (HiDPI) scaling issues in TkinterDnD2, Using ctypes on Windows to set SetProcessDPIAware or utilizing tk.tk.call('tk', 'scaling', factor) can correct blurry or wrongly sized drag-and-drop interfaces.

### on 150% scale 4K screen, before: 

<img width="541" height="504" alt="before" src="https://github.com/user-attachments/assets/9630d6e3-8215-4658-b2ca-cc5e7d3f9ebf" />

### on 150% scale 4K screen, after: 

<img width="361" height="343" alt="after" src="https://github.com/user-attachments/assets/49db4036-bc2c-4ba7-a71c-0b20a9b9f0fc" />
